### PR TITLE
Zloeber/fix deps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,84 @@ jobs:
           name: python-package-distributions
           path: dist/
 
+  semantic-tag:
+    name: Create semantic version tag
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Calculate version bump from commit prefixes
+        id: semver
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          latest_tag="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
+          if [[ -z "${latest_tag}" ]]; then
+            latest_tag="v0.0.0"
+            range="HEAD"
+          else
+            range="${latest_tag}..HEAD"
+          fi
+
+          commit_text="$(git log "${range}" --pretty=%s%n%b)"
+          bump="patch"
+
+          if echo "${commit_text}" | grep -Eq 'BREAKING CHANGE|^[[:alpha:]]+(\([^)]+\))?!:'; then
+            bump="major"
+          elif echo "${commit_text}" | grep -Eq '^feat(\([^)]+\))?:'; then
+            bump="minor"
+          fi
+
+          current="${latest_tag#v}"
+          IFS='.' read -r major minor patch <<< "${current}"
+
+          case "${bump}" in
+            major)
+              major=$((major + 1))
+              minor=0
+              patch=0
+              ;;
+            minor)
+              minor=$((minor + 1))
+              patch=0
+              ;;
+            patch)
+              patch=$((patch + 1))
+              ;;
+          esac
+
+          next_tag="v${major}.${minor}.${patch}"
+          echo "latest_tag=${latest_tag}" >> "$GITHUB_OUTPUT"
+          echo "next_tag=${next_tag}" >> "$GITHUB_OUTPUT"
+          echo "bump=${bump}" >> "$GITHUB_OUTPUT"
+
+      - name: Skip if tag already exists
+        id: tag_check
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git rev-parse "${{ steps.semver.outputs.next_tag }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.tag_check.outputs.exists == 'false'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git tag "${{ steps.semver.outputs.next_tag }}"
+          git push origin "${{ steps.semver.outputs.next_tag }}"
+          echo "Created ${{ steps.semver.outputs.next_tag }} (${{ steps.semver.outputs.bump }})"
+
   publish-to-pypi:
     name: Publish Python 🐍 distribution 📦 to PyPI
     runs-on: ubuntu-latest

--- a/.mex/AGENTS.md
+++ b/.mex/AGENTS.md
@@ -15,6 +15,7 @@ Metagit CLI manages and validates repository/workspace metadata (`.metagit.yml`)
 - Keep mutating repo operations explicitly guarded (especially MCP sync modes).
 - Put business logic in `src/metagit/core/*`; keep CLI command handlers thin.
 - Run lint + relevant tests before claiming a change is complete.
+- Default commit messages to patch semantics (`fix:`). Use `feat:` only for additive backward-compatible changes, and use major/breaking prefixes only when schema/config compatibility is intentionally broken.
 
 ## Commands
 - Setup: `./configure.sh && task install`

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -33,6 +33,8 @@ Then read this file fully before doing anything else in this session.
 - Workspace index/search/upstream hint services and guarded repo inspect/sync flows.
 - Skill scaffold + local wrapper scripts in `skills/*/scripts` for token-efficient agent workflows.
 - Runtime packaging compatibility path for version lookup and `python -m metagit` entrypoint behavior in minimal Python environments.
+- Docs build path resolves CLI imports correctly in CI by including interactive prompt runtime dependency.
+- Semantic version tags are auto-created on merges to `main` from commit prefixes (`fix:` patch, `feat:` minor, breaking markers major) and drive tag-based release publishing.
 
 **Not yet built:**
 - Full production-grade MCP lifecycle extras (e.g., richer notifications, broader method surface, advanced capability negotiation details).
@@ -71,3 +73,8 @@ For every task, follow this loop:
    - If a pattern exists but you deviated from it or discovered a new gotcha, update it with what you learned.
    - If any `context/` file is now out of date because of this work, update it surgically — do not rewrite entire files.
    - Update the "Current Project State" section above if the work was significant.
+
+## Commit Message Semantics
+- Use `fix:` by default (patch-level intent).
+- Use `feat:` only for additive backward-compatible behavior.
+- Use breaking-change markers (`type(scope)!:` or `BREAKING CHANGE:`) only when intentionally breaking schema/config compatibility (for example `.metagit.yml` or app configuration schema changes).

--- a/.mex/SETUP.md
+++ b/.mex/SETUP.md
@@ -226,3 +226,7 @@ Once the scaffold is populated, use these to keep it aligned with your codebase:
 - **`mex check`** — detect drift (zero tokens, zero AI)
 - **`.mex/sync.sh`** — interactive drift check + targeted or full resync
 - **`mex watch`** — auto drift score after every commit
+
+## Commit Prefix Policy
+
+When committing scaffold updates, default to `fix:` (patch intent). Use `feat:` only for additive backward-compatible updates. Use breaking markers (`type(scope)!:` or `BREAKING CHANGE:`) only for intentional schema/config compatibility breaks.

--- a/.mex/SYNC.md
+++ b/.mex/SYNC.md
@@ -54,6 +54,7 @@ Critical rules for updating:
 - In all other files: update content to reflect current reality
 - Update last_updated in the YAML frontmatter of every file you change
 - After updating each file, update ROUTER.md Current Project State
+- Commit-message semantics: default to `fix:` for patch-level updates; use `feat:` only for additive backward-compatible changes; use breaking markers only when intentionally breaking schema/config compatibility.
 
 When done, report:
 - Which files were updated and what changed

--- a/.mex/context/conventions.md
+++ b/.mex/context/conventions.md
@@ -62,3 +62,8 @@ Before presenting any code:
 - [ ] `.metagit.yml`/config model interactions still pass validation paths (no silent schema drift).
 - [ ] Lint/format checks pass via project commands (`task lint`, and format if needed).
 - [ ] Mutating operations remain explicitly guarded (especially MCP sync/tool paths).
+
+## Commit Semantics
+- Default to `fix:` commit prefixes (patch intent) for normal maintenance and safe behavior updates.
+- Use `feat:` only for additive backward-compatible capabilities.
+- Use `type(scope)!:` or `BREAKING CHANGE:` only when changes intentionally break schema/config compatibility.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ In this mode metagit connects to our enterprise SaaS offering to help mine the w
 
 **uv:**
 
-`uv tool install metagit-ai`
+`uv tool install metagit-cli` (PyPI project name; the unrelated `metagit` package is a different tool.)
 
 **From source:**
 To install metagit, clone the repository and build the project:
@@ -342,6 +342,16 @@ The default configuration file is `metagit.config.yaml`, which can be customized
 ## Contributing
 
 Contributions are welcome! Please open an issue or submit a pull request for any enhancements or bug fixes.
+
+### Versioning and Release Prefixes
+
+Merges to `main` trigger semantic tag creation (`vX.Y.Z`) based on commit message prefixes:
+
+- `fix:` -> patch bump
+- `feat:` -> minor bump
+- `type(scope)!:` or `BREAKING CHANGE:` -> major bump
+
+Default to `fix:` unless the change is additive (`feat:`) or intentionally breaks schema/config compatibility (major markers).
 
 ## License
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -31,14 +31,11 @@ includes:
   github:
     taskfile: ./tasks/Taskfile.github.yml
     optional: true
-  git:
-    taskfile: ./tasks/Taskfile.git.yml
-    optional: true
-  precommit:
-    taskfile: ./tasks/Taskfile.precommit.yml
-    optional: true
   python:
     taskfile: ./tasks/Taskfile.python.yml
+    optional: true
+  mcp:
+    taskfile: ./tasks/Taskfile.mcp.yml
     optional: true
 
 tasks:

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,3 +15,19 @@ task format lint:fix test
   - `inactive_missing_config` when `.metagit.yml` is not present
   - `inactive_invalid_config` when `.metagit.yml` fails validation
   - `active` when `.metagit.yml` loads successfully
+
+## Semantic Release Tags
+
+Merges to `main` automatically create a semantic version tag (`vX.Y.Z`) based on commit message prefixes since the previous tag.
+
+- `fix:` -> patch release (`X.Y.Z+1`) **default for most updates**
+- `feat:` -> minor release (`X.Y+1.0`)
+- `type(scope)!:` or `BREAKING CHANGE:` -> major release (`X+1.0.0`)
+
+### Commit Prefix Guidance
+
+Use patch semantics first (`fix:`) unless schema/config compatibility is intentionally broken.
+
+- Use `fix:` for normal maintenance and safe behavior changes.
+- Use `feat:` only for additive, backward-compatible functionality.
+- Use `!` / `BREAKING CHANGE` when changing `.metagit.yml` or app config schema in a non-backward-compatible way.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "textual-dev>=1.7.0",
     "tomli>=2.2.1",
     "python-hcl2>=7.3.1",
+    "prompt-toolkit>=3.0.51",
 ]
 
 [project.urls]

--- a/src/metagit/core/utils/userprompt.py
+++ b/src/metagit/core/utils/userprompt.py
@@ -3,32 +3,69 @@
 UserPrompt utility for dynamically prompting users for Pydantic object properties.
 """
 
+from __future__ import annotations
+
 import json
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Type, TypeVar, Union
 
-from prompt_toolkit import PromptSession
-from prompt_toolkit.formatted_text import FormattedText
-from prompt_toolkit.shortcuts import print_formatted_text
-from prompt_toolkit.styles import Style
-from prompt_toolkit.validation import ValidationError as PTValidationError
-from prompt_toolkit.validation import Validator
 from pydantic import BaseModel, ValidationError
 
 T = TypeVar("T", bound=BaseModel)
 
-# Define styles for different prompt elements
-PROMPT_STYLE = Style.from_dict(
-    {
-        "title": "bold cyan",
-        "field": "bold green",
-        "description": "italic yellow",
-        "default": "blue",
-        "error": "bold red",
-        "success": "bold green",
-        "optional": "white",
-        "prompt": "white",
-    }
-)
+_pt_cache: Optional[SimpleNamespace] = None
+_prompt_style_cache: Any = None
+
+
+def _promptkit() -> SimpleNamespace:
+    """
+    Lazily import prompt_toolkit so CLI modules can load without it.
+
+    Interactive commands require the dependency; install with metagit-cli or
+    ``pip install 'prompt-toolkit>=3.0'``.
+    """
+    global _pt_cache
+    if _pt_cache is None:
+        try:
+            from prompt_toolkit import PromptSession
+            from prompt_toolkit.formatted_text import FormattedText
+            from prompt_toolkit.shortcuts import print_formatted_text
+            from prompt_toolkit.styles import Style
+            from prompt_toolkit.validation import ValidationError as PTValidationError
+            from prompt_toolkit.validation import Validator
+        except ImportError as exc:
+            raise ImportError(
+                "Interactive prompts require 'prompt-toolkit'. "
+                "Install: pip install 'prompt-toolkit>=3.0' or reinstall metagit-cli."
+            ) from exc
+        _pt_cache = SimpleNamespace(
+            PromptSession=PromptSession,
+            FormattedText=FormattedText,
+            print_formatted_text=print_formatted_text,
+            Style=Style,
+            PTValidationError=PTValidationError,
+            Validator=Validator,
+        )
+    return _pt_cache
+
+
+def _prompt_style() -> Any:
+    global _prompt_style_cache
+    if _prompt_style_cache is None:
+        pk = _promptkit()
+        _prompt_style_cache = pk.Style.from_dict(
+            {
+                "title": "bold cyan",
+                "field": "bold green",
+                "description": "italic yellow",
+                "default": "blue",
+                "error": "bold red",
+                "success": "bold green",
+                "optional": "white",
+                "prompt": "white",
+            }
+        )
+    return _prompt_style_cache
 
 
 class UserPrompt:
@@ -39,8 +76,9 @@ class UserPrompt:
     fields of any Pydantic model, with validation and type conversion using prompt_toolkit.
     """
 
-    def __init__(self):
-        self.session = PromptSession(style=PROMPT_STYLE)
+    def __init__(self) -> None:
+        pk = _promptkit()
+        self.session = pk.PromptSession(style=_prompt_style())
 
     @staticmethod
     def prompt_for_model(
@@ -70,6 +108,7 @@ class UserPrompt:
             if not issubclass(model_class, BaseModel):
                 return ValueError(f"{model_class} is not a valid Pydantic model")
 
+            pk = _promptkit()
             existing_data = existing_data or {}
             field_data = {}
             prompt_instance = UserPrompt()
@@ -79,14 +118,14 @@ class UserPrompt:
 
             if title:
                 # Print title
-                title_text = FormattedText([("class:title", f"\n=== {title} ===\n")])
-                print_formatted_text(title_text)
+                title_text = pk.FormattedText([("class:title", f"\n=== {title} ===\n")])
+                pk.print_formatted_text(title_text)
 
             for field_name, field_info in model_fields.items():
                 # Skip if field already has a value
                 if field_name in existing_data:
                     field_data[field_name] = existing_data[field_name]
-                    success_text = FormattedText(
+                    success_text = pk.FormattedText(
                         [
                             ("class:success", f"✓ {field_name}: "),
                             (
@@ -95,7 +134,7 @@ class UserPrompt:
                             ),
                         ]
                     )
-                    print_formatted_text(success_text)
+                    pk.print_formatted_text(success_text)
                     continue
 
                 # If fields_to_prompt is specified, only prompt for those fields
@@ -133,10 +172,11 @@ class UserPrompt:
             try:
                 return model_class(**field_data)
             except ValidationError as e:
-                error_text = FormattedText(
+                pk = _promptkit()
+                error_text = pk.FormattedText(
                     [("class:error", f"\n❌ Validation error: {e}\n")]
                 )
-                print_formatted_text(error_text)
+                pk.print_formatted_text(error_text)
                 # Retry with corrected data
                 return UserPrompt.prompt_for_model(
                     model_class, field_data, title, fields_to_prompt
@@ -158,6 +198,7 @@ class UserPrompt:
             The user input value, converted to appropriate type
         """
         try:
+            pk = _promptkit()
             field_type = field_info.annotation
             description = field_info.description or ""
 
@@ -193,7 +234,7 @@ class UserPrompt:
 
             prompt_parts.append(("class:prompt", ": "))
 
-            prompt_text = FormattedText(prompt_parts)
+            prompt_text = pk.FormattedText(prompt_parts)
 
             # Create validator for the field type
             validator = self._create_field_validator(field_type, field_info)
@@ -217,7 +258,7 @@ class UserPrompt:
 
                     # Handle empty input for required fields
                     if not user_input and field_info.is_required():
-                        error_text = FormattedText(
+                        error_text = pk.FormattedText(
                             [
                                 (
                                     "class:error",
@@ -225,23 +266,25 @@ class UserPrompt:
                                 )
                             ]
                         )
-                        print_formatted_text(error_text)
+                        pk.print_formatted_text(error_text)
                         continue
 
                     # Convert and return the input
                     converted_value = self._convert_input(user_input, field_type)
                     if isinstance(converted_value, Exception):
                         # This should be caught by the validator, but as a fallback
-                        error_text = FormattedText(
+                        error_text = pk.FormattedText(
                             [("class:error", f"❌ {converted_value}\n")]
                         )
-                        print_formatted_text(error_text)
+                        pk.print_formatted_text(error_text)
                         continue
                     return converted_value
 
-                except PTValidationError as e:
-                    error_text = FormattedText([("class:error", f"❌ {e.message}\n")])
-                    print_formatted_text(error_text)
+                except pk.PTValidationError as e:
+                    error_text = pk.FormattedText(
+                        [("class:error", f"❌ {e.message}\n")]
+                    )
+                    pk.print_formatted_text(error_text)
                     continue
         except Exception as e:
             return e
@@ -260,6 +303,7 @@ class UserPrompt:
             The user input value (converted to appropriate type) or None if no value provided
         """
         try:
+            pk = _promptkit()
             field_type = field_info.annotation
             description = field_info.description or ""
 
@@ -304,7 +348,7 @@ class UserPrompt:
 
             prompt_parts.append(("class:prompt", ": "))
 
-            prompt_text = FormattedText(prompt_parts)
+            prompt_text = pk.FormattedText(prompt_parts)
 
             # Create validator for the field type
             validator = self._create_field_validator(field_type, field_info)
@@ -334,23 +378,25 @@ class UserPrompt:
                     converted_value = self._convert_input(user_input, field_type)
                     if isinstance(converted_value, Exception):
                         # This should be caught by the validator, but as a fallback
-                        error_text = FormattedText(
+                        error_text = pk.FormattedText(
                             [("class:error", f"❌ {converted_value}\n")]
                         )
-                        print_formatted_text(error_text)
+                        pk.print_formatted_text(error_text)
                         continue
                     return converted_value
 
-                except PTValidationError as e:
-                    error_text = FormattedText([("class:error", f"❌ {e.message}\n")])
-                    print_formatted_text(error_text)
+                except pk.PTValidationError as e:
+                    error_text = pk.FormattedText(
+                        [("class:error", f"❌ {e.message}\n")]
+                    )
+                    pk.print_formatted_text(error_text)
                     continue
         except Exception as e:
             return e
 
     def _create_field_validator(
         self, field_type: Any, field_info: Any = None
-    ) -> Union[Optional[Validator], Exception]:
+    ) -> Union[Any, Exception]:
         """
         Create a validator for the given field type.
 
@@ -363,6 +409,7 @@ class UserPrompt:
             A prompt_toolkit Validator instance or None
         """
         try:
+            pk = _promptkit()
 
             def validate_type(text: str) -> bool:
                 if not text:
@@ -386,19 +433,18 @@ class UserPrompt:
                 if is_bool_field:
                     if text.strip().lower() in ["true", "false", "y", "n", "yes", "no"]:
                         return True
-                    else:
-                        raise PTValidationError(
-                            message="Please enter 'true', 'false', 'y', or 'n'"
-                        )
+                    raise pk.PTValidationError(
+                        message="Please enter 'true', 'false', 'y', or 'n'"
+                    )
 
                 # For other types, try to convert
                 try:
                     self._convert_input(text, field_type)
                     return True
                 except (ValueError, TypeError) as exc:
-                    raise PTValidationError(message=f"Invalid value: {exc}") from exc
+                    raise pk.PTValidationError(message=f"Invalid value: {exc}") from exc
 
-            return Validator.from_callable(validate_type)
+            return pk.Validator.from_callable(validate_type)
         except Exception as e:
             return e
 
@@ -457,10 +503,9 @@ class UserPrompt:
             if target_type is bool:
                 if user_input.lower() in ["true", "y", "yes"]:
                     return True
-                elif user_input.lower() in ["false", "n", "no"]:
+                if user_input.lower() in ["false", "n", "no"]:
                     return False
-                else:
-                    raise ValueError(f"Cannot convert '{user_input}' to boolean")
+                raise ValueError(f"Cannot convert '{user_input}' to boolean")
 
             # Default conversion
             try:
@@ -499,8 +544,6 @@ class UserPrompt:
                 "default": default,
             }
             # Mock field_info object for _prompt_for_field
-            from types import SimpleNamespace
-
             mock_field_info = SimpleNamespace(
                 annotation=field_type,
                 description=description,
@@ -523,20 +566,20 @@ class UserPrompt:
             bool: True if user confirms, False otherwise
         """
         try:
-            session = PromptSession(style=PROMPT_STYLE)
-            prompt_text = FormattedText([("class:field", f"\n{message} (y/n): ")])
+            pk = _promptkit()
+            session = pk.PromptSession(style=_prompt_style())
+            prompt_text = pk.FormattedText([("class:field", f"\n{message} (y/n): ")])
 
             while True:
                 response = session.prompt(prompt_text).strip().lower()
                 if response in ["y", "yes"]:
                     return True
-                elif response in ["n", "no"]:
+                if response in ["n", "no"]:
                     return False
-                else:
-                    error_text = FormattedText(
-                        [("class:error", "❌ Please enter 'y' or 'n'.\n")]
-                    )
-                    print_formatted_text(error_text)
+                error_text = pk.FormattedText(
+                    [("class:error", "❌ Please enter 'y' or 'n'.\n")]
+                )
+                pk.print_formatted_text(error_text)
         except Exception as e:
             return e
 
@@ -582,9 +625,8 @@ def yes_no_prompt(message: str = "Continue?") -> bool:
             response = input(f"{message} (y/n): ").lower().strip()
             if response in ["y", "yes"]:
                 return True
-            elif response in ["n", "no"]:
+            if response in ["n", "no"]:
                 return False
-            else:
-                print("Please enter 'y' or 'n'")
+            print("Please enter 'y' or 'n'")
     except Exception:
         return False

--- a/tasks/Taskfile.mcp.yml
+++ b/tasks/Taskfile.mcp.yml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+
+version: "3"
+silent: true
+
+tasks:
+  show:
+    desc: Show MCP variables for this task
+    cmds:
+      - |
+        echo "OLLAMA_HOST: {{.OLLAMA_HOST}}"
+
+  inspector:
+    desc: Start MCP Inspector
+    cmds:
+      - npx -y @modelcontextprotocol/inspector
+    env:
+      DANGEROUSLY_OMIT_AUTH: true
+
+  scan:
+    desc: Scan MCP package for issues
+    env:
+      MCP_SCANNER_LLM_API_KEY: test
+      MCP_SCANNER_API_KEY: test
+      MCP_SCANNER_LLM_ENDPOINT: $OLLAMA_HOST
+      MCP_SCANNER_LLM_MODEL: gemma4:31b
+    cmds:
+      - |
+        uv tool install cisco-ai-mcp-scanner
+        uv tool upgrade cisco-ai-mcp-scanner
+        mcp-scanner --format summary \
+          --stdio-command uvx \
+          --stdio-arg=pl-cli --stdio-arg=mcp --stdio-arg=-c --stdio-arg=config.yaml \
+          --stdio-arg=--no-ingest-on-startup \
+          --format table \
+          --analyzers yara \
+          -o security_scan_results.md

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1498,6 +1498,7 @@ dependencies = [
     { name = "litellm" },
     { name = "logging" },
     { name = "loguru" },
+    { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pygithub" },
     { name = "python-dotenv" },
@@ -1588,6 +1589,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'lint'" },
     { name = "mypy", marker = "extra == 'test'" },
     { name = "mypy", marker = "extra == 'typecheck'" },
+    { name = "prompt-toolkit", specifier = ">=3.0.51" },
     { name = "pydantic", specifier = ">=2.11.4" },
     { name = "pygithub", specifier = ">=2.6.1" },
     { name = "pytest", marker = "extra == 'test'" },


### PR DESCRIPTION
## Description
[Provide a detailed description of the changes in this PR]

## Related Issues
[Link to related issues using #issue-number format]

## Documentation PR
[Link to related associated PR in the repo]

## Type of Change
- Bug fix
- New feature
- Breaking change
- Documentation update
- Other (please describe):

[Choose one of the above types of changes]

## Testing
[How have you tested the change?]

## Checklist
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline to auto-generate and push version tags based on commit messages, which can affect published versions if the tag logic misclassifies changes. Also adjusts runtime dependency loading for interactive prompts, which may impact CLI startup behavior if prompt dependencies are missing.
> 
> **Overview**
> **Release automation:** The GitHub Actions release workflow now creates and pushes a `vX.Y.Z` tag on `main` pushes by scanning commit messages since the last tag (`fix:` → patch, `feat:` → minor, breaking markers → major); existing tag pushes still gate PyPI/TestPyPI publishing.
> 
> **CLI/deps & tooling:** Adds `prompt-toolkit` as a project dependency and refactors `UserPrompt` to *lazily import* `prompt_toolkit` (with a clearer error if missing) so non-interactive CLI modules can load without it. Adds an MCP task namespace (`tasks/Taskfile.mcp.yml`) and updates docs/scaffold guidance to standardize commit prefixes for the new semver tagging scheme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d5eea2e319d93641ea7bfee3f3ea4a62f0bfb67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->