### PR TITLE
feat(campaign): schema superset — goal/reference_impl/timestamps, explicit --repo, legacy compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+- **Campaign schema superset:** `CampaignDocument` gains optional `goal`, `reference_impl`, `created`, and `updated` fields; `campaign new` accepts an explicit `--repo project/repo` (repeatable, frozen set — no query drift) as an alternative to `--query`, plus `--goal` and `--reference`; `campaign status` surfaces goal/reference.
+- **Legacy overlay compatibility:** campaign documents authored before the native schema now load without a rewrite — integer `schema_version`, `status: complete` (→ `completed`), and list-form `selection.tags` (→ map) are coerced on load. Point native at an existing overlay dir via `workspace.campaigns_path` / `METAGIT_WORKSPACE_CAMPAIGNS_PATH`.
+
 
 
 ## [0.14.1] - 2026-07-07

--- a/docs/reference/campaigns.md
+++ b/docs/reference/campaigns.md
@@ -25,7 +25,11 @@ schema_version: "1.0"
 slug: tier-full-rollout
 title: Full-tier agent rollout
 status: active          # draft | active | completed | archived
+goal: Roll every platform repo onto the full agent tier   # optional free-text objective
+reference_impl: platform/api   # optional exemplar repo other repos model their change on
 objective_id: optional-spine-objective-id
+created: "2026-07-06T12:00:00+00:00"   # stamped on create
+updated: "2026-07-06T18:30:00+00:00"   # refreshed on set
 selection:
   query: platform
   tags:
@@ -43,20 +47,36 @@ lessons:
     recorded_at: "2026-07-06T18:00:00+00:00"
 ```
 
+> **Legacy compatibility.** Documents authored before the native schema are read
+> without a rewrite: an integer `schema_version`, a `status: complete` alias
+> (normalized to `completed`), and a list-form `selection.tags` (normalized to a
+> map) are all coerced on load. Point native at an existing overlay directory with
+> `workspace.campaigns_path` (app config) or `METAGIT_WORKSPACE_CAMPAIGNS_PATH`.
+
 ## CLI
 
 | Command | Purpose |
 |---------|---------|
 | `metagit campaign list` | Summary table + rollup counts |
-| `metagit campaign status --slug <s>` | Per-repo status, MRs, notes |
+| `metagit campaign status --slug <s>` | Per-repo status, MRs, notes (plus goal/reference) |
 | `metagit campaign new --slug <s> --title "…" --query "…"` | Resolve repos via `metagit find`, freeze `repos[]` |
+| `metagit campaign new --slug <s> --title "…" --repo p/r --repo p/r2` | Freeze an **explicit** repo set (no query drift) |
 | `metagit campaign validate` | Schema + every repo exists in atlas |
 | `metagit campaign set --slug <s> --repo project/repo --status merged [--mr URL] [--note "…"]` | Update one repo row |
 | `metagit campaign expand --slug <s> [--tag k=v] [--dry-run]` | One spine objective per matching repo |
 
+`campaign new` accepts **either** `--query` (dynamic resolution) **or** one or more
+`--repo project/repo` (explicit frozen set); at least one is required. Optional
+`--goal` and `--reference project/repo` annotate the campaign.
+
 ```bash
+# Query-resolved selection
 metagit campaign new --slug tier-full --title "Full tier rollout" --query "platform" \
-  --tag agent_tier=full
+  --tag agent_tier=full --goal "Roll platform repos onto full tier"
+# Explicit frozen selection with an exemplar repo
+metagit campaign new --slug vibe-app --title "Ship the vibe app" \
+  --repo ai/publish-aws --repo gdo/shared-terraform-modules \
+  --reference ai/publish-aws --goal "Containerize and deploy on ECS"
 metagit campaign status --slug tier-full --json
 metagit campaign set --slug tier-full --repo platform/api --status mr-open --mr "https://…"
 metagit campaign expand --slug tier-full --dry-run

--- a/src/metagit/cli/commands/campaign.py
+++ b/src/metagit/cli/commands/campaign.py
@@ -119,6 +119,10 @@ def campaign_status(ctx: click.Context, slug: str, definition_path: str, as_json
         _emit_json(result.model_dump(mode="json"))
         return
     click.echo(f"{result.campaign.title} ({result.campaign.status})")
+    if result.campaign.goal:
+        click.echo(f"goal: {result.campaign.goal}")
+    if result.campaign.reference_impl:
+        click.echo(f"reference: {result.campaign.reference_impl}")
     click.echo(
         f"rollup: {result.merged_count} merged, {result.open_mr_count} MRs open, "
         f"{result.blocked_count} blocked, {result.pending_count} pending",
@@ -132,8 +136,20 @@ def campaign_status(ctx: click.Context, slug: str, definition_path: str, as_json
 @campaign.command("new")
 @click.option("--slug", required=True, help="Campaign slug (filename stem).")
 @click.option("--title", required=True, help="Human-readable campaign title.")
-@click.option("--query", required=True, help="Repository selection query (metagit find syntax).")
+@click.option(
+    "--query",
+    default=None,
+    help="Repository selection query (metagit find syntax). Provide this or --repo.",
+)
+@click.option(
+    "--repo",
+    "repo_selectors",
+    multiple=True,
+    help="Explicit project/repo to include (repeatable). Freezes the repo set (no query drift).",
+)
 @click.option("--tag", "tag_values", multiple=True, help="Optional tag filter during selection.")
+@click.option("--goal", default=None, help="Free-text objective describing what the campaign delivers.")
+@click.option("--reference", "reference_impl", default=None, help="Exemplar repo (project/repo) to model changes on.")
 @click.option("--objective-id", default=None, help="Optional spine objective id to bind.")
 @click.option(
     "--definition",
@@ -147,13 +163,16 @@ def campaign_new(
     ctx: click.Context,
     slug: str,
     title: str,
-    query: str,
+    query: Optional[str],
+    repo_selectors: tuple[str, ...],
     tag_values: tuple[str, ...],
+    goal: Optional[str],
+    reference_impl: Optional[str],
     objective_id: Optional[str],
     definition_path: str,
     as_json: bool,
 ) -> None:
-    """Create a campaign by resolving repos from a query."""
+    """Create a campaign by resolving repos from a query or an explicit --repo list."""
     _ = ctx
     service, _ = _campaign_service(definition_path, config_path=ctx.obj.get("config_path"))
     try:
@@ -161,8 +180,11 @@ def campaign_new(
             slug=slug,
             title=title,
             query=query,
+            repos=list(repo_selectors) or None,
             tag_filters=_parse_tag_filters(tag_values),
             objective_id=objective_id,
+            goal=goal,
+            reference_impl=reference_impl,
         )
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/metagit/core/campaign/models.py
+++ b/src/metagit/core/campaign/models.py
@@ -3,12 +3,38 @@
 
 from __future__ import annotations
 
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 CampaignStatus = Literal["draft", "active", "completed", "archived"]
 CampaignRepoStatus = Literal["pending", "routed", "mr-open", "merged", "blocked"]
+
+# Legacy status aliases accepted on load and normalized to the canonical enum.
+# Supports overlays authored before the native schema existed (e.g. SRAM's
+# ``task campaign:*`` layer which wrote ``complete`` instead of ``completed``).
+_STATUS_ALIASES = {"complete": "completed", "done": "completed", "in-progress": "active"}
+
+
+def _coerce_tags(value: Any) -> dict[str, str]:
+    """Normalize a tag filter set to a dict.
+
+    Legacy overlays wrote ``selection.tags`` as a list (often empty, or
+    ``key=value`` strings). Native uses a dict. Accept both so pre-existing
+    campaign documents load without a rewrite.
+    """
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return {str(k): str(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        parsed: dict[str, str] = {}
+        for item in value:
+            if isinstance(item, str) and "=" in item:
+                key, val = item.split("=", 1)
+                parsed[key] = val
+        return parsed
+    return {}
 
 
 class CampaignSelection(BaseModel):
@@ -20,6 +46,11 @@ class CampaignSelection(BaseModel):
         default=None,
         description="ISO timestamp when repos[] was frozen",
     )
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def _normalize_tags(cls, value: Any) -> dict[str, str]:
+        return _coerce_tags(value)
 
 
 class CampaignRepoEntry(BaseModel):
@@ -47,13 +78,44 @@ class CampaignDocument(BaseModel):
     slug: str
     title: str
     status: CampaignStatus = Field(default="draft")
+    goal: Optional[str] = Field(
+        default=None,
+        description="Free-text objective describing what the campaign delivers",
+    )
+    reference_impl: Optional[str] = Field(
+        default=None,
+        description="Exemplar repo (project/repo) to model other repos' changes on",
+    )
     objective_id: Optional[str] = Field(
         default=None,
         description="Optional 1:1 spine objective id",
     )
+    created: Optional[str] = Field(
+        default=None,
+        description="ISO date/timestamp the campaign was created",
+    )
+    updated: Optional[str] = Field(
+        default=None,
+        description="ISO date/timestamp the campaign was last modified",
+    )
     selection: CampaignSelection = Field(default_factory=CampaignSelection)
     repos: list[CampaignRepoEntry] = Field(default_factory=list)
     lessons: list[CampaignLesson] = Field(default_factory=list)
+
+    @field_validator("schema_version", mode="before")
+    @classmethod
+    def _coerce_schema_version(cls, value: Any) -> str:
+        # Legacy overlays wrote an integer (schema_version: 1); native types it str.
+        if value is None:
+            return "1.0"
+        return str(value)
+
+    @field_validator("status", mode="before")
+    @classmethod
+    def _normalize_status(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return _STATUS_ALIASES.get(value, value)
+        return value
 
 
 class CampaignListItem(BaseModel):

--- a/src/metagit/core/campaign/service.py
+++ b/src/metagit/core/campaign/service.py
@@ -84,25 +84,38 @@ class CampaignService:
         *,
         slug: str,
         title: str,
-        query: str,
+        query: Optional[str] = None,
+        repos: Optional[list[str]] = None,
         tag_filters: Optional[dict[str, str]] = None,
         objective_id: Optional[str] = None,
+        goal: Optional[str] = None,
+        reference_impl: Optional[str] = None,
     ) -> CampaignDocument:
         existing = self.load(slug)
         if existing is not None:
             raise ValueError(f"Campaign already exists: {slug!r}")
-        repos = self._resolve_selection(query=query, tag_filters=tag_filters)
+        if not query and not repos:
+            raise ValueError("Provide --query or at least one --repo to select campaign repos.")
+        if repos:
+            repo_entries = self._explicit_selection(repos)
+        else:
+            repo_entries = self._resolve_selection(query=query or "", tag_filters=tag_filters)
+        now = datetime.now(timezone.utc).isoformat()
         campaign = CampaignDocument(
             slug=slug,
             title=title,
             status="draft",
+            goal=goal,
+            reference_impl=reference_impl,
             objective_id=objective_id,
+            created=now,
+            updated=now,
             selection=CampaignSelection(
                 query=query,
                 tags=dict(tag_filters or {}),
-                resolved_at=datetime.now(timezone.utc).isoformat(),
+                resolved_at=now,
             ),
-            repos=repos,
+            repos=repo_entries,
         )
         self._save(campaign)
         return campaign
@@ -142,6 +155,7 @@ class CampaignService:
                 entry.mr = mr
             if note is not None:
                 entry.note = note
+            campaign.updated = datetime.now(timezone.utc).isoformat()
             self._save(campaign)
             return campaign
         raise ValueError(f"Repo not in campaign {slug!r}: {key}")
@@ -195,6 +209,26 @@ class CampaignService:
 
         tags = merge_project_repo_tags(project, repo)
         return all(tags.get(key) == value for key, value in filters.items())
+
+    def _explicit_selection(self, repos: list[str]) -> list[CampaignRepoEntry]:
+        """Build a frozen repo set from explicit ``project/repo`` selectors.
+
+        Unlike query resolution, this does not re-resolve against the atlas on
+        every run — the campaign's repo set is fixed at creation time (no query
+        drift). Atlas membership is enforced later by ``validate_all``.
+        """
+        entries: list[CampaignRepoEntry] = []
+        seen: set[str] = set()
+        for selector in repos:
+            if "/" not in selector:
+                raise ValueError(f"--repo must be project/repo, got {selector!r}")
+            project, repo_name = selector.split("/", 1)
+            key = f"{project}/{repo_name}"
+            if key in seen:
+                continue
+            seen.add(key)
+            entries.append(CampaignRepoEntry(project=project, repo=repo_name, status="pending"))
+        return entries
 
     def _resolve_selection(
         self,

--- a/tests/core/campaign/test_campaign_service.py
+++ b/tests/core/campaign/test_campaign_service.py
@@ -84,3 +84,98 @@ def test_campaign_expand_dry_run(tmp_path: Path) -> None:
     result = service.expand(slug="expand-me", session_root=tmp_path, dry_run=True)
     assert len(result.objective_ids) == 1
     assert result.objective_ids[0].startswith("campaign-expand-me-")
+
+
+def test_campaign_create_with_explicit_repos_freezes_selection(tmp_path: Path) -> None:
+    config = _sample_config()
+    service = CampaignService(config=config, definition_root=tmp_path)
+    campaign = service.create(
+        slug="frozen",
+        title="Frozen set",
+        repos=["demo/alpha", "demo/beta", "demo/alpha"],  # dupe ignored
+        goal="Ship the thing",
+        reference_impl="demo/alpha",
+    )
+    # Explicit set is frozen verbatim (no query drift), deduped, order preserved.
+    assert [f"{r.project}/{r.repo}" for r in campaign.repos] == ["demo/alpha", "demo/beta"]
+    assert campaign.selection.query is None
+    assert campaign.selection.resolved_at is not None
+    assert campaign.goal == "Ship the thing"
+    assert campaign.reference_impl == "demo/alpha"
+    assert campaign.created is not None and campaign.updated is not None
+
+
+def test_campaign_create_requires_query_or_repos(tmp_path: Path) -> None:
+    config = _sample_config()
+    service = CampaignService(config=config, definition_root=tmp_path)
+    try:
+        service.create(slug="empty", title="Empty")
+    except ValueError as exc:
+        assert "--query or at least one --repo" in str(exc)
+    else:  # pragma: no cover - guard must raise
+        raise AssertionError("expected ValueError when no selection provided")
+
+
+def test_campaign_explicit_repo_bad_selector(tmp_path: Path) -> None:
+    config = _sample_config()
+    service = CampaignService(config=config, definition_root=tmp_path)
+    try:
+        service.create(slug="bad", title="Bad", repos=["no-slash"])
+    except ValueError as exc:
+        assert "project/repo" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError for malformed --repo selector")
+
+
+def test_campaign_set_repo_status_stamps_updated(tmp_path: Path) -> None:
+    config = _sample_config()
+    service = CampaignService(config=config, definition_root=tmp_path)
+    created = service.create(slug="stamp", title="Stamp", repos=["demo/alpha"])
+    original_updated = created.updated
+    assert original_updated is not None
+    changed = service.set_repo_status(slug="stamp", project="demo", repo="alpha", status="mr-open")
+    assert changed.updated is not None
+    assert changed.updated >= original_updated
+
+
+def test_campaign_loads_legacy_document(tmp_path: Path) -> None:
+    """A pre-native overlay (int schema_version, `complete` status, list tags)
+    loads without a rewrite via the compatibility normalizers."""
+    config = _sample_config()
+    service = CampaignService(
+        config=config,
+        definition_root=tmp_path,
+        campaigns_path="knowledge/campaigns",
+    )
+    service.campaigns_dir().mkdir(parents=True, exist_ok=True)
+    legacy = (
+        "schema_version: 1\n"
+        "slug: legacy\n"
+        "title: Legacy overlay\n"
+        "status: complete\n"
+        "goal: pre-existing goal\n"
+        "reference_impl: demo/alpha\n"
+        "selection:\n"
+        "  query:\n"
+        "  tags: []\n"
+        "repos:\n"
+        "  - project: demo\n"
+        "    repo: alpha\n"
+        "    role: app\n"
+        "    status: merged\n"
+        "lessons: []\n"
+    )
+    (service.campaigns_dir() / "legacy.yml").write_text(legacy, encoding="utf-8")
+
+    loaded = service.load("legacy")
+    assert loaded is not None
+    assert loaded.schema_version == "1"  # coerced int -> str
+    assert loaded.status == "completed"  # complete -> completed
+    assert loaded.selection.tags == {}  # [] -> {}
+    assert loaded.goal == "pre-existing goal"
+    assert loaded.reference_impl == "demo/alpha"
+    assert loaded.repos[0].role == "app"
+
+    # And it participates in list/status rollups cleanly.
+    summary = service.list_campaigns()
+    assert any(item.slug == "legacy" and item.status == "completed" for item in summary.campaigns)


### PR DESCRIPTION
## Why
Native campaigns (0.14.x) and pre-native overlay layers. This extends the native schema into a **superset** so an existing overlay directory can be adopted by native metagit

## What
**Model** (`core/campaign/models.py`) — additive optional fields `goal`, `reference_impl`, `created`, `updated`; compatibility normalizers on load:
- int `schema_version` → str
- `status: complete|done|in-progress` → canonical enum (`completed`/`active`)
- list-form `selection.tags` → dict

**Service** (`core/campaign/service.py`) — `create()` accepts an explicit `repos=[project/repo]` **frozen set** (deduped, order-preserved, no query drift) as an alternative to a find query; stamps `created`/`updated`; `set_repo_status()` refreshes `updated`.

**CLI** (`cli/commands/campaign.py`) — `campaign new` gains `--repo` (repeatable), `--goal`, `--reference`; `--query` now optional (one of query/repos required). `campaign status` surfaces goal/reference.

**Docs + tests** — `campaigns.md` document shape, CLI table, legacy-compat note; 5 new service tests.

## Compatibility
Fully additive and backward-compatible (`feat:`). Existing `_campaigns/` documents and CLI invocations are unaffected.

## Gate
`task qa:prepush` (14 checks incl. changelog, unit, e2e, security) ✅ · `task gitnexus:analyze` ✅

_Note: 3 tests (`test_project_select_*`, `test_appconfig_show_includes_dedupe_and_agent_mode`) fail locally only when `METAGIT_AGENT_MODE` is exported in the shell (disables the picker they mock); they pass in a clean env and are unrelated to this change._
