### PR TITLE
fix(tests): make suite independent of METAGIT_AGENT_MODE in the shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- **Test suite env independence:** an autouse fixture now clears `METAGIT_AGENT_MODE` before each test so a value exported in the caller's shell (common in agent/automation shells) can't disable interactive paths and cause spurious failures in CLI picker and appconfig-display tests. Tests needing the variable set it explicitly.
+
 
 
 ## [0.15.0] - 2026-07-07

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,22 @@ def cleanup_logging():
     logger.remove()
 
 
+@pytest.fixture(autouse=True)
+def clear_agent_mode_env(monkeypatch):
+    """Ensure a stray ``METAGIT_AGENT_MODE`` in the caller's shell can't leak
+    into tests.
+
+    Several CLI tests exercise interactive paths (the fuzzy-finder picker) or
+    assert the default ``agent_mode`` posture. When ``METAGIT_AGENT_MODE`` is
+    exported in the environment running pytest (common in agent/automation
+    shells), it silently disables those paths and the tests fail spuriously.
+    Clearing it per-test makes the suite env-independent. Tests that need the
+    variable set it explicitly with ``monkeypatch.setenv`` after this fixture
+    has run.
+    """
+    monkeypatch.delenv("METAGIT_AGENT_MODE", raising=False)
+
+
 @pytest.fixture
 def temp_dir():
     """Create a temporary directory for test use."""


### PR DESCRIPTION
## Why
Three tests fail spuriously when `METAGIT_AGENT_MODE` is exported in the shell running pytest (common in agent/automation shells):
- `tests/cli/commands/test_project.py::test_project_select_missing_default_uses_single_project`
- `tests/cli/commands/test_project_select_repo.py::test_project_select_repo_skips_picker_and_opens_editor`
- `tests/test_appconfig_display.py::test_appconfig_show_includes_dedupe_and_agent_mode`

The variable silently disables interactive code paths (the fuzzy-finder picker) and flips the default `agent_mode` posture, so the mocks/assertions in those tests never fire. They pass in a clean env and fail with the var set — a hidden dependency on the caller's shell.

## Fix
An autouse fixture in `tests/conftest.py` clears `METAGIT_AGENT_MODE` before each test, making the whole suite env-independent (not just these three — any future test is protected too). The one test that genuinely needs the variable, `test_metagit_agent_mode_env_overrides_config`, sets it explicitly with `monkeypatch.setenv` after the fixture runs, so it's unaffected.

## Verification
`task qa:prepush` passes **with `METAGIT_AGENT_MODE=true` exported in the shell** — the exact condition that previously reproduced the failures. `task gitnexus:analyze` green.

Scope: `tests/conftest.py` + CHANGELOG. No product code touched.
