### PR TITLE
fix(docs): unblock mkdocs strict build for rewrite guide links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-
+### Fixed
+- **Docs CI (`mkdocs build --strict`):** replace relative links from `docs/metagit-rewrite-workspace.md` to `examples/metagit-rewrite/*` with GitHub blob URLs so MkDocs no longer aborts on out-of-tree targets.
 
 ## [0.18.0] - 2026-07-09
 

--- a/docs/metagit-rewrite-workspace.md
+++ b/docs/metagit-rewrite-workspace.md
@@ -27,7 +27,7 @@ metagit init --target ./rewrite-coordinator --create --template metagit-rewrite 
 
 ### Option B — copy the example manifest
 
-Copy [examples/metagit-rewrite/.metagit.yml](../examples/metagit-rewrite/.metagit.yml)
+Copy [examples/metagit-rewrite/.metagit.yml](https://github.com/metagit-ai/metagit-cli/blob/main/examples/metagit-rewrite/.metagit.yml)
 into your coordinator repository and adjust repo URLs.
 
 ### Wire app config and sync
@@ -77,7 +77,7 @@ Cloned repos appear under your configured `workspace.path` (default `./.metagit`
 | Active task | objectives JSON | `rewrite-foundation-config-manager` |
 | Cross-repo semantics | `graph.relationships` | `target` **implements** `source` |
 
-See [objectives.example.json](../examples/metagit-rewrite/objectives.example.json)
+See [objectives.example.json](https://github.com/metagit-ai/metagit-cli/blob/main/examples/metagit-rewrite/objectives.example.json)
 for sample objective payloads.
 
 ## Orchestrator workflow


### PR DESCRIPTION
## Summary
- Replace relative `../examples/metagit-rewrite/*` links in `docs/metagit-rewrite-workspace.md` with GitHub blob URLs so `mkdocs build --strict` no longer aborts docs CI.
- Record the fix in `CHANGELOG.md` Unreleased.

## Test plan
- [x] `task docs` (`mkdocs build --strict`) succeeds locally
- [ ] Confirm Docs workflow passes on this PR / after merge to main