### PR TITLE
fix(logging): route console sink to stderr so MCP stdio stays clean

### DIFF
--- a/src/metagit/core/utils/logging.py
+++ b/src/metagit/core/utils/logging.py
@@ -160,9 +160,14 @@ class UnifiedLogger(LoggerProtocol):
             )
             serialize = False
 
-        # Console sink
+        # Console sink.
+        # NOTE: this MUST target stderr, never stdout. When metagit runs as an
+        # MCP server over stdio (`metagit mcp serve`), stdout is reserved
+        # exclusively for JSON-RPC frames; any human-readable log line written
+        # to stdout corrupts the transport and breaks the client handshake
+        # (loguru's own default sink is stderr for exactly this reason).
         self._stdout_handler_id = logger.add(
-            sys.stdout,
+            sys.stderr,
             level=config.log_level,
             format=log_format,
             backtrace=config.backtrace,
@@ -199,11 +204,12 @@ class UnifiedLogger(LoggerProtocol):
             self.config.log_level = level
             self.debug_mode = level == "DEBUG" or level == "TRACE"
 
-            # Update stdout handler
+            # Update stdout handler (stderr sink — see __init__ note: stdout is
+            # reserved for MCP stdio JSON-RPC and must stay clean).
             if self._stdout_handler_id is not None:
                 logger.remove(self._stdout_handler_id)
                 self._stdout_handler_id = logger.add(
-                    sys.stdout,
+                    sys.stderr,
                     level=level,
                     format=(
                         "{message}"

--- a/tests/test_utils_logging.py
+++ b/tests/test_utils_logging.py
@@ -3,7 +3,10 @@
 Unit tests for metagit.core.utils.logging
 """
 
+from loguru import logger as loguru_logger
+
 from metagit.core.utils import logging as metagit_logging
+from metagit.core.utils.logging import LoggerConfig, UnifiedLogger
 
 
 def test_get_logger_returns_logger():
@@ -33,3 +36,43 @@ def test_logger_log_levels(monkeypatch):
     assert debug_result is None
     assert info_result is None
     assert error_result is None
+
+
+def test_console_sink_writes_to_stderr_not_stdout(capsys):
+    """Regression: the console sink MUST target stderr, never stdout.
+
+    When metagit runs as an MCP server over stdio (`metagit mcp serve`), stdout
+    is reserved exclusively for JSON-RPC frames. A human-readable log line on
+    stdout corrupts the transport and breaks the client handshake with
+    `Invalid JSON: expected value at line 1 column 1`. This test guards against
+    a regression to `logger.add(sys.stdout, ...)`.
+    """
+    ul = UnifiedLogger(LoggerConfig(log_level="INFO"))
+    try:
+        ul.info("mcp-stdio-canary")
+        loguru_logger.complete()  # flush enqueue=True sink
+    finally:
+        # Tear the handler down so the loguru global logger is left clean for
+        # other tests regardless of assertion outcome.
+        loguru_logger.remove()
+
+    captured = capsys.readouterr()
+    assert "mcp-stdio-canary" not in captured.out, (
+        "console log leaked to stdout — this breaks MCP stdio JSON-RPC"
+    )
+    assert "mcp-stdio-canary" in captured.err
+
+
+def test_set_level_keeps_console_sink_on_stderr(capsys):
+    """set_level() rebuilds the console handler; it must stay on stderr too."""
+    ul = UnifiedLogger(LoggerConfig(log_level="INFO"))
+    try:
+        ul.set_level("DEBUG")
+        ul.info("mcp-stdio-canary-2")
+        loguru_logger.complete()
+    finally:
+        loguru_logger.remove()
+
+    captured = capsys.readouterr()
+    assert "mcp-stdio-canary-2" not in captured.out
+    assert "mcp-stdio-canary-2" in captured.err


### PR DESCRIPTION
## Problem

Starting the Metagit MCP server over stdio (`metagit mcp serve`) fails the client handshake with:

```
pydantic_core.ValidationError: 1 validation error for JSONRPCMessage
  Invalid JSON: expected value at line 1 column 1
    input_value='Metagit MCP stdio runtime initialized.'
```

In MCP's stdio transport, **stdout carries only JSON-RPC frames** — the client parses every stdout line as JSON. But `UnifiedLogger` added its console sink to `sys.stdout`, so the startup banner logged at `src/metagit/cli/commands/mcp.py:42` (`logger.info("Metagit MCP stdio runtime initialized.")`) landed on stdout and broke the transport on the very first read. This tears down the connection `TaskGroup`, and when metagit is co-launched with other stdio MCP servers (e.g. `secretzero`) it takes them down as collateral.

## Root cause

`src/metagit/core/utils/logging.py` — both console sinks (in `__init__` and in `set_level`) targeted `sys.stdout`. loguru's own default sink is stderr precisely so logs never collide with a program's stdout data stream.

## Fix

Point both console sinks at `sys.stderr`. stdout is now clean until a genuine JSON-RPC reply; the banner and all log output go to stderr, where MCP clients ignore it.

## Verification

Before:
```
$ metagit mcp serve </dev/null 1>out 2>err
$ head -1 out
Metagit MCP stdio runtime initialized.      # <- on STDOUT, breaks MCP
```

After:
```
$ metagit mcp serve </dev/null 1>out 2>err
$ head -1 out         # <empty> stdout clean
$ head -1 err
Metagit MCP stdio runtime initialized.      # <- now on STDERR
```

Adds regression tests (`tests/test_utils_logging.py`) asserting the console sink writes to stderr and never stdout, covering both the initial handler and the `set_level()` rebuild path. Full logging suite: 4 passed.
